### PR TITLE
DRUPSIBLE-140 Added blackfire.ini for the CLI tool. Added several

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,25 +21,46 @@ Role Variables
 ``` yaml
     # Sets the server id used to authenticate with Blackfire API
     #blackfire_server_id: __CHANGE_THIS_VALUE__
-    
+        
     # Sets the server token used to authenticate with Blackfire API. It is unsafe to set this from the command line
     #blackfire_server_token: __CHANGE_THIS_VALUE__
-    
+        
     # Log verbosity level (4: debug, 3: info, 2: warning, 1: error)
     blackfire_log_level: 1
-    
+        
     # Sets the socket the agent should read traces from.
     # Possible value can be a unix socket or a TCP address. ie: unix:///var/run/blackfire/agent.sock or tcp://127.0.0.1:8307
     blackfire_socket: "unix:///var/run/blackfire/agent.sock"
-    
+        
     # Sets the URL of Blackfire's data collector
     blackfire_collector: https://blackfire.io
-    
+        
     # Restart apache after the activation of blackfire php extension
     blackfire_apache_enable: false
-    
+        
     # Restart php fpm after the activation of blackfire php extension
     blackfire_php_fpm_enable: true
+    
+    # CLI tool
+    
+    # Sets the Client ID used for API authentication
+    #blackfire_client_id
+    
+    # Sets the Client Token used for API authentication
+    #blackfire_client_token
+    
+    # User of the CLI tool
+    blackfire_user: root
+    blackfire_user_directory: '/root'
+    
+    # Other params configurable as well
+    blackfire_ca_cert: ""
+    blackfire_http_proxy: ""
+    blackfire_https_proxy: ""
+    blackfire_timeout: '15s'
+    blackfire_log_file: 'stderr'
+    blackfire_socket: 'unix:///var/run/blackfire/agent.sock'
+    blackfire_spec: ''
 ```
 
 Dependencies
@@ -53,10 +74,11 @@ Example Playbook
 ``` yaml
     - hosts: all
       roles:
-         - { role: AbdoulNdiaye.Blackfire }
-      vars:
-        blackfire_server_id:    __CHANGE_THIS_VALUE__
-        blackfire_server_token: __CHANGE_THIS_VALUE__
+      - role: AbdoulNdiaye.Blackfire
+        tags: blackfire
+        vars:
+          blackfire_server_id:    __CHANGE_THIS_VALUE__
+          blackfire_server_token: __CHANGE_THIS_VALUE__
 ```
 
 FAQ

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,3 +22,24 @@ blackfire_apache_enable: false
 
 # Restart php fpm after the activation of blackfire php extension
 blackfire_php_fpm_enable: true
+
+# Blackfire CLI tool
+
+# Sets the Client ID used for API authentication
+#blackfire_client_id: ""
+
+# Sets the Client ID used for API authentication
+#blackfire_client_token: ""
+
+# User of the CLI tool
+blackfire_user: root
+blackfire_user_directory: "{{ (blackfire_user == 'root') | ternary('/root', '/home/' + blackfire_user) }}"
+
+# Other params configurable as well
+blackfire_ca_cert: ""
+blackfire_http_proxy: ""
+blackfire_https_proxy: ""
+blackfire_timeout: '15s'
+blackfire_log_file: 'stderr'
+blackfire_socket: 'unix:///var/run/blackfire/agent.sock'
+blackfire_spec: ''

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,9 +1,9 @@
 ---
 galaxy_info:
-  author: Abdoul N'Diaye
+  author: Abdoul N'Diaye, Mariano Barcia
   description: Blackfire installation
   license: MIT
-  min_ansible_version: 1.4
+  min_ansible_version: 2.0
   #
   # Below are all platforms currently available. Just uncomment
   # the ones that apply to your role. If you don't see your 
@@ -18,6 +18,7 @@ galaxy_info:
   - name: Debian
     versions:
     - wheezy
+    - jessie
   #
   # Below are all categories currently available. Just as with
   # the platforms above, uncomment those that apply to your role.
@@ -27,9 +28,3 @@ galaxy_info:
   - monitoring
   - system
   - web
-dependencies: []
-  # List your role dependencies here, one per line. Only
-  # dependencies available via galaxy should be listed here.
-  # Be sure to remove the '[]' above if you add dependencies
-  # to this list.
-  

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,19 +2,21 @@
 # tasks file for blackfire.
 
 - name: Include OS specific vars
-  tags: blackfire
   include_vars: "os_family/{{ ansible_os_family }}.yml"
 
 - include: os_family/Debian.yml
-  tags: blackfire
   when: ansible_os_family == 'Debian'
 
 - include: os_family/RedHat.yml
-  tags: blackfire
   when: ansible_os_family == 'RedHat'
 
+- name: Install the blackfire-agent package
+  package: name=blackfire-agent state=present
+
+- name: Install the blackfire-php package
+  package: name=blackfire-php state=present
+
 - name: Create agent configuration
-  tags: blackfire
   template:
     src=agent.j2
     dest={{ blackfire_directory }}/agent
@@ -23,8 +25,15 @@
     mode=0644
   register: agent_configuration_state
 
+- name: Create CLI tool configuration file
+  template:
+    src=blackfire.ini.j2
+    dest="{{ blackfire_user_directory }}/.blackfire.ini"
+    owner="{{ blackfire_user }}"
+    mode=0644
+  when: blackfire_client_id|default('') != "" and blackfire_client_token|default('') != ""
+
 - name: Service blackfire-agent restart
-  tags: blackfire
   sudo: true
   service: name=blackfire-agent state=restarted
   notify:
@@ -33,6 +42,5 @@
   when: agent_configuration_state|changed
 
 - name: Restart apache if enable in configuration
-  tags: blackfire
   service: name=apache2 state=restarted
   when: blackfire_apache_enable

--- a/tasks/os_family/Debian.yml
+++ b/tasks/os_family/Debian.yml
@@ -1,27 +1,13 @@
 ---
-
 ## Debian tasks
 
-- name: Install Curl
-  apt: name=curl state=present
-
 - name: Register the packagecloud key
-  tags: blackfire
   apt_key:
     url: "{{ blackfire_package_cloud_key_url }}"
     state: present
 
 - name: Add Blackfire package list in source.list
-  tags: blackfire
   apt_repository:
     repo: 'deb {{ blackfire_package_url }} any main'
     state: present
     update_cache: yes
-
-- name: Install the blackfire-agent package
-  tags: blackfire
-  apt: name=blackfire-agent state=present
-
-- name: Install the blackfire-php package
-  tags: blackfire
-  apt: name=blackfire-php state=present

--- a/tasks/os_family/RedHat.yml
+++ b/tasks/os_family/RedHat.yml
@@ -1,22 +1,16 @@
 ---
-
 ## RedHat tasks
-
-- name: Install Curl
-  yum: name=curl state=present
+- name: curl installed
+  package: name=curl state=present
 
 - name: Install the pygpgme package used to verify GPG signatures
-  tags: blackfire
-  yum: name=pygpgme state=present
+  package: name=pygpgme state=present
 
 - name: Add Blackfire repository to the configuration
-  tags: blackfire
   shell: curl "{{ blackfire_repository }}" | sudo tee /etc/yum.repos.d/blackfire.repo
 
 - name: Install the blackfire-agent package
-  tags: blackfire
   yum: name=blackfire-agent state=present update_cache=yes
 
 - name: Install the blackfire-php package
-  tags: blackfire
-  yum: name=blackfire-php state=present
+  package: name=blackfire-php state=present

--- a/templates/agent.j2
+++ b/templates/agent.j2
@@ -8,37 +8,37 @@
 ; setting: ca-cert
 ; desc   : Sets the PEM encoded certicates
 ; default:
-ca-cert=
+ca-cert={{ blackfire_ca_cert }}
 
 ;
 ; setting: collector
 ; desc   : Sets the URL of Blackfire's data collector
 ; default: https://blackfire.io
-collector={{ blackfire_collector }}
+collector={{ blackfire_collector|default('https://blackfire.io') }}
 
 ;
 ; setting: http-proxy
 ; desc   : Sets the http proxy to use
 ; default:
-http-proxy=
+http-proxy={{ blackfire_http_proxy }}
 
 ;
 ; setting: https-proxy
 ; desc   : Sets the https proxy to use
 ; default:
-https-proxy=
+https-proxy={{ blackfire_https_proxy }}
 
 ;
 ; setting: log-file
 ; desc   : Sets the path of the log file. Use stderr to log to stderr
 ; default: stderr
-log-file=stderr
+log-file={{ blackfire_log_file|default('stderr') }}
 
 ;
 ; setting: log-level
 ; desc   : log verbosity level (4: debug, 3: info, 2: warning, 1: error)
 ; default: 1
-log-level={{ blackfire_log_level }}
+log-level={{ blackfire_log_level|default(1) }}
 
 ;
 ; setting: server-id
@@ -56,11 +56,10 @@ server-token={{ blackfire_server_token }}
 ; setting: socket
 ; desc   : Sets the socket the agent should read traces from. Possible value can be a unix socket or a TCP address. ie: unix:///var/run/blackfire/agent.sock or tcp://127.0.0.1:8307
 ; default: unix:///var/run/blackfire/agent.sock
-socket={{ blackfire_socket }}
+socket={{ blackfire_socket|default('unix:///var/run/blackfire/agent.sock') }}
 
 ;
 ; setting: spec
 ; desc   : Sets the path to the json specifications file
 ; default:
-spec=
-
+spec={{ blackfire_spec }}

--- a/templates/blackfire.ini.j2
+++ b/templates/blackfire.ini.j2
@@ -1,0 +1,46 @@
+[blackfire]
+;
+; This is a configuration file for Blackfire.
+;
+
+;
+; setting: ca-cert
+; desc   : Sets the PEM encoded certificates to use
+; default:
+ca-cert={{ blackfire_ca_cert }}
+
+;
+; setting: client-id
+; desc   : Sets the Client ID used for API authentication
+; default:
+client-id={{ blackfire_client_id }}
+
+;
+; setting: client-token
+; desc   : Sets the Client Token used for API authentication
+; default:
+client-token={{ blackfire_client_token }}
+
+;
+; setting: endpoint
+; desc   : Sets the API endpoint
+; default: https://blackfire.io
+endpoint=https://blackfire.io
+
+;
+; setting: http-proxy
+; desc   : Sets the http proxy to use
+; default:
+http-proxy={{ blackfire_http_proxy }}
+
+;
+; setting: https-proxy
+; desc   : Sets the https proxy to use
+; default:
+https-proxy={{ blackfire_https_proxy }}
+
+;
+; setting: timeout
+; desc   : Sets the Blackfire API connection timeout
+; default: 15s
+timeout={{ blackfire_timeout|default('15s') }}


### PR DESCRIPTION
variables, including client_id and client_token. Replaced apt/yum by
package where possible. Removed curl installation in Debian. Added more
variables for a 100% coverage of Blackfire parameters. Removed
blackfire tag. Updated doc.

Signed-off-by: Mariano Barcia <mariano.barcia@gmail.com>